### PR TITLE
Add l2Bridge address to Hemi sepolia chain for Sepolia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "husky": "4.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Viem extension for the Hemi Network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/chains/hemi-sepolia.ts
+++ b/src/chains/hemi-sepolia.ts
@@ -43,6 +43,11 @@ export const hemiSepolia = defineChain({
         address: "0xc94b1BEe63A3e101FE5F71C80F912b4F4b055925",
       },
     },
+    l2Bridge: {
+      [sourceId]: {
+        address: "0x4200000000000000000000000000000000000010",
+      },
+    },
     l2OutputOracle: {
       [sourceId]: {
         address: "0x032d1e1dd960A4B027a9a35FF8B2b672E333Bc27",


### PR DESCRIPTION
Closes #16

This PR adds the `l2Bridge` for the pair "Hemi Sepolia" - "Ethereum Sepolia"

## Changes

- 9b9c1bba06dfb88d5cc3778c6b76df2fd562f4c8 Adds the `0x4200000000000000000000000000000000000010` address 
- 7bd41db0d153357a397c3034e6486fb15cc7e259 Bumps the version to `1.5.0`