### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "peerDependencies": {
     "viem": "^2.x"
   },
+  "repository": "hemilabs/hemi-viem",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
This PR adds the repository field, so next time a npm version is published (not needed for this change), the repo will be linked in npm.

Closes #19 