### PR TITLE
Rename eth native currencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Viem extension for the Hemi Network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/chains/hemi-sepolia.ts
+++ b/src/chains/hemi-sepolia.ts
@@ -9,7 +9,7 @@ export const hemiSepolia = defineChain({
   name: "Hemi Sepolia",
   nativeCurrency: {
     decimals: 18,
-    name: "Testnet Hemi Ether",
+    name: "Ether",
     symbol: "ETH",
   },
   rpcUrls: {

--- a/src/chains/hemi.ts
+++ b/src/chains/hemi.ts
@@ -9,7 +9,7 @@ export const hemi = defineChain({
   name: "Hemi Network",
   nativeCurrency: {
     decimals: 18,
-    name: "Hemi Ether",
+    name: "Ether",
     symbol: "ETH",
   },
   rpcUrls: {


### PR DESCRIPTION
Closes #26

`Ether` and `Testnet Hemi Ether` renamed to plain `Ether`. I bumped to `1.6.1` assuming that the names were incorrect, and that we were fixing them 😄 