### PR TITLE
Add support to commonjs module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["bloq", "prettier"],
-  "ignorePatterns": ["_esm/*", "_types/*"],
+  "ignorePatterns": ["_esm/*", "_cjs/*", "_types/*"],
   "overrides": [
     {
       "extends": ["bloq/typescript", "prettier"],

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _esm
+_cjs
 _types
 .DS_Store
 .eslintcache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Viem extension for the Hemi Network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"
@@ -17,6 +17,7 @@
     }
   ],
   "files": [
+    "_cjs",
     "_esm",
     "_types",
     "src/**/*.ts"
@@ -24,10 +25,11 @@
   "main": "./_esm/index.js",
   "repository": "hemilabs/hemi-viem",
   "scripts": {
-    "build": "npm run clean && npm run build:esm && npm run build:types",
+    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:types",
+    "build:cjs": "tsc --noEmit false --module CommonJS --outDir ./_cjs --sourceMap && echo '{\"type\":\"commonjs\"}' > ./_cjs/package.json",
     "build:esm": "tsc --noEmit false --outDir ./_esm --sourceMap",
     "build:types": "tsc --module esnext --declarationDir ./_types --emitDeclarationOnly --declaration --declarationMap",
-    "clean": "rm -rf ./_esm ./_types",
+    "clean": "rm -rf ./_esm ./_cjs ./_types",
     "deps:check": "knip",
     "format:check": "prettier --check .",
     "lint": "eslint --cache .",
@@ -53,6 +55,7 @@
   "exports": {
     ".": {
       "import": "./_esm/index.js",
+      "require": "./_cjs/index.js",
       "types": "./_types/index.d.ts"
     }
   },


### PR DESCRIPTION
This PR adds support to `commonjs` module and also bumps the package version.

Tests:
 This changes were tested with `npm link` and `npm pack`, on commonjs and ES Module projects.

Closes #31 