### PR TITLE
Add bitcoin tunnel manager address for hemi

### DIFF
--- a/src/contracts/bitcoin-tunnel-manager.ts
+++ b/src/contracts/bitcoin-tunnel-manager.ts
@@ -1,7 +1,9 @@
 import { type Address, type Chain } from "viem";
+import { hemi } from "../chains/hemi.js";
 import { hemiSepolia } from "../chains/hemi-sepolia.js";
 
 export const bitcoinTunnelManagerAddresses: Record<Chain["id"], Address> = {
+  [hemi.id]: "0xEAcA824F46c000fB89403846Bb57e6b913321081",
   [hemiSepolia.id]: "0x8221CFD3Eca3c5F9FA27b2AE774151642f1C449e",
 };
 


### PR DESCRIPTION
Closes #35 

This PR adds the Bitcoin Tunnel Manager address for Hemi Mainnet. I checked in the explorer that the ABI matches with the hardcoded abi in this repo (since the contract is verified).