### PR TITLE
Add methods min deposit withrawal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Viem extension for the Hemi Network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/public/simple-bitcoin-vault.ts
+++ b/src/actions/public/simple-bitcoin-vault.ts
@@ -41,6 +41,32 @@ export function getBitcoinWithdrawalGracePeriod(
   });
 }
 
+export const getMinimumDepositSats = function (
+  client: Client,
+  parameters: { vaultAddress: Address },
+) {
+  const { vaultAddress } = parameters;
+  return readContract(client, {
+    abi: simpleBitcoinVaultAbi,
+    address: vaultAddress,
+    args: [],
+    functionName: "MINIMUM_DEPOSIT_SATS",
+  });
+};
+
+export const getMinimumWithdrawalSats = function (
+  client: Client,
+  parameters: { vaultAddress: Address },
+) {
+  const { vaultAddress } = parameters;
+  return readContract(client, {
+    abi: simpleBitcoinVaultAbi,
+    address: vaultAddress,
+    args: [],
+    functionName: "MINIMUM_WITHDRAWAL_SATS",
+  });
+};
+
 export function getVaultStatus(
   client: Client,
   parameters: { vaultAddress: Address },


### PR DESCRIPTION
Related to https://github.com/hemilabs/ui-monorepo/issues/725

We need to read the minimum values for depositing/withdrawing from the contracts. These functions are in the vaults. This PR adds these methods.