### PR TITLE
Prepend '0x' to tx Ids in getTxConfirmations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Viem extension for the Hemi Network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/public/bitcoin-kit.ts
+++ b/src/actions/public/bitcoin-kit.ts
@@ -58,13 +58,14 @@ export function getTransactionByTxId(
 
 export function getTxConfirmations(
   client: Client,
-  parameters: { bitcoinKitAddress: Address; txId: Hash },
+  parameters: { bitcoinKitAddress: Address; txId: string },
 ) {
   const { bitcoinKitAddress, txId } = parameters;
+  const hash: Hash = isHash(txId) ? txId : `0x${txId}`;
   return readContract(client, {
     abi: bitcoinKitTxsAbi,
     address: bitcoinKitAddress,
-    args: [txId],
+    args: [hash],
     functionName: "getTxConfirmations",
   });
 }


### PR DESCRIPTION
This PR adds `0x` to call Bitcoin Kit's `getTxConfirmations`, so consumers of the package don't have to manually pre-pend `0x`