### PR TITLE
Bump some deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,25 +10,25 @@
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
-        "better-sort-package-json": "^1.1.0",
+        "better-sort-package-json": "1.1.1",
         "commitlint-config-bloq": "^1.0.0",
         "eslint": "^8.57.1",
-        "eslint-config-bloq": "^4.4.1",
+        "eslint-config-bloq": "4.5.0",
         "husky": "^9.1.7",
         "knip": "^5.41.1",
         "lint-staged": "^15.3.0",
-        "prettier": "^3.4.2",
+        "prettier": "3.5.3",
         "typescript": "^5.7.2",
-        "viem": "2.7.19"
+        "viem": "2.22.10"
       },
       "peerDependencies": {
         "viem": "^2.x"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
       "dev": true,
       "license": "MIT"
     },
@@ -903,26 +903,42 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1270,9 +1286,9 @@
       "dev": true
     },
     "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1280,29 +1296,29 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1719,9 +1735,9 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.0.tgz",
-      "integrity": "sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2075,10 +2091,11 @@
       "dev": true
     },
     "node_modules/better-sort-package-json": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/better-sort-package-json/-/better-sort-package-json-1.1.0.tgz",
-      "integrity": "sha512-4CWZMU5m/AmhBfa0hwj3ZRXszh1fiej+g+Kw170NJ4xhcp4I5FdOx2HPdoNNkUZzXfqM50q5x4fadBG4PmIdUQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/better-sort-package-json/-/better-sort-package-json-1.1.1.tgz",
+      "integrity": "sha512-U+l8hoUOWftGscRJS8nHWxFvnBsT3Jpvr/lLqlRJ1QgGk+y6cAwtzU4UxXc+DSgrRxQqAxwMeVre7Vit59656w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-stable-stringify": "^1.1.1"
       },
@@ -3046,9 +3063,9 @@
       }
     },
     "node_modules/eslint-config-bloq": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.4.1.tgz",
-      "integrity": "sha512-LnNd+2kwkZCZmQVfGXz6pd3K5OGvElRJgWmmno5vNCQ48Ek/h3q90hZHRq/717QjO8tduIJ28ddI4IbaRu0e5w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-bloq/-/eslint-config-bloq-4.5.0.tgz",
+      "integrity": "sha512-O2jXso6vNnTMTYaYCUn9uGA9yUmH2m3gvHIB3xARGFO32pSHoAMdE0SN61VLfQAIW0OQiym4PHOM7yZJSvDePQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3063,7 +3080,8 @@
         "eslint-plugin-mocha": "^10.0.0",
         "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-prefer-arrow": "^1.0.0",
-        "eslint-plugin-promise": "^6.0.0"
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-sort-destructure-keys": "^2.0.0"
       },
       "peerDependencies": {
         "eslint": "^8.0.0"
@@ -3662,6 +3680,22 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-sort-destructure-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-destructure-keys/-/eslint-plugin-sort-destructure-keys-2.0.0.tgz",
+      "integrity": "sha512-4w1UQCa3o/YdfWaLr9jY8LfGowwjwjmwClyFLxIsToiyIdZMq3x9Ti44nDn34DtTPP7PWg96tUONKVmATKhYGQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "natural-compare-lite": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "5 - 9"
       }
     },
     "node_modules/eslint-scope": {
@@ -5051,14 +5085,14 @@
       "dev": true
     },
     "node_modules/isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
+          "url": "https://github.com/sponsors/wevm"
         }
       ],
       "license": "MIT",
@@ -5777,6 +5811,13 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -5954,6 +5995,36 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.5.tgz",
+      "integrity": "sha512-vmnH8KvMDwFZDbNY1mq2CBRBWIgSliZB/dFV0xKp+DfF/dJkTENt6nmA+DzHSSAgL/GO2ydjkXWvlndJgSY4KQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -6186,9 +6257,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7263,9 +7334,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.7.19",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.7.19.tgz",
-      "integrity": "sha512-UOMeqy+8p2709ra2j9HEOL1NfjsXZzlJ8gwR6YO/zXH8KIZvyzW07t4iQARF5+ShVZ/7+/1ec8oPjVi1M//33A==",
+      "version": "2.22.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.22.10.tgz",
+      "integrity": "sha512-amYq+bxD3k9gUx4JXzKtpKrnw1Mc3f4s32g6Axo8twpum+47r+9M2g+qh63gzrs0goTTVUsmg3n9ev+zELKRDw==",
       "dev": true,
       "funding": [
         {
@@ -7275,14 +7346,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "1.0.0",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.6.1",
+        "@scure/bip32": "1.6.0",
+        "@scure/bip39": "1.5.0",
+        "abitype": "1.0.7",
+        "isows": "1.0.6",
+        "ox": "0.6.5",
+        "ws": "8.18.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -7631,9 +7702,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -39,16 +39,16 @@
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
-    "better-sort-package-json": "^1.1.0",
+    "better-sort-package-json": "1.1.1",
     "commitlint-config-bloq": "^1.0.0",
     "eslint": "^8.57.1",
-    "eslint-config-bloq": "^4.4.1",
+    "eslint-config-bloq": "4.5.0",
     "husky": "^9.1.7",
     "knip": "^5.41.1",
     "lint-staged": "^15.3.0",
-    "prettier": "^3.4.2",
+    "prettier": "3.5.3",
     "typescript": "^5.7.2",
-    "viem": "2.7.19"
+    "viem": "2.22.10"
   },
   "peerDependencies": {
     "viem": "^2.x"


### PR DESCRIPTION
Bumping some deps. Now `viem` matches the version on the ui-monorepo.

No need to publish a new version for this