### PR TITLE
Update link to Bitcoin Kit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It includes:
 
 - Chain definitions!
 - [Bitcoin finality](https://docs.hemi.xyz/foundational-topics/pop-consensus-and-bitcoin-finality) helper!
-- [Bitcoin Kit](https://github.com/hemilabs/research/blob/main/research/Bitcoin-kit.md) wrappers!
+- [Bitcoin Kit](https://docs.hemi.xyz/building-bitcoin-apps/hemi-bitcoin-kit-hbk) wrappers!
 
 ## Installation
 


### PR DESCRIPTION
Closes #42 

I updated the Bitcoin Kit link to point to [hemi docs](https://docs.hemi.xyz/building-bitcoin-apps/hemi-bitcoin-kit-hbk)

No need to bump the version