### PR TITLE
Add Bitcoin Tunnel encoders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.3.3",
+      "version": "2.4.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Viem extension for the Hemi network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/public/bitcoin-tunnel-encoders.ts
+++ b/src/actions/public/bitcoin-tunnel-encoders.ts
@@ -1,0 +1,82 @@
+import { encodeFunctionData, Hash, isHash } from "viem";
+import { bitcoinTunnelManagerAbi } from "../../contracts";
+
+/**
+ * Encodes the transaction data for challenging a BTC withdrawal using the `challengeWithdrawal` function.
+ *
+ * @param {Object} parameters - The transaction parameters.
+ * @param {bigint} parameters.uuid - The UUID of the withdrawal to challenge.
+ * @param {Hash} [parameters.extraInfo] - Optional extra info passed as bytes. Defaults to '0x' if not provided.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeChallengeWithdrawal = ({
+  uuid,
+  extraInfo,
+}: {
+  uuid: bigint;
+  extraInfo?: Hash;
+}) =>
+  encodeFunctionData({
+    abi: bitcoinTunnelManagerAbi,
+    args: [uuid, extraInfo ?? "0x"],
+    functionName: "challengeWithdrawal",
+  });
+
+/**
+ * Encodes the transaction data for confirming a BTC deposit using the `confirmDeposit` function.
+ *
+ * @param {Object} parameters - The transaction parameters.
+ * @param {number} parameters.vaultIndex - The index of the vault handling the deposit.
+ * @param {string} parameters.txId - The BTC transaction ID to confirm (with or without 0x prefix).
+ * @param {bigint} parameters.outputIndex - The output index in the BTC transaction.
+ * @param {Hash} parameters.extraInfo - Additional encoded metadata.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeConfirmDeposit = ({
+  vaultIndex,
+  txId,
+  outputIndex,
+  extraInfo,
+}: {
+  vaultIndex: number;
+  txId: string;
+  outputIndex: bigint;
+  extraInfo: Hash;
+}) =>
+  encodeFunctionData({
+    abi: bitcoinTunnelManagerAbi,
+    args: [
+      vaultIndex,
+      isHash(txId) ? txId : `0x${txId}`,
+      outputIndex,
+      extraInfo,
+    ],
+    functionName: "confirmDeposit",
+  });
+
+/**
+ * Encodes the transaction data for initiating a BTC withdrawal using the `initiateWithdrawal` function.
+ *
+ * @param {Object} parameters - The transaction parameters.
+ * @param {number} parameters.vaultIndex - The index of the vault initiating the withdrawal.
+ * @param {string} parameters.btcAddress - The recipient's BTC address (must be valid bech32 format).
+ * @param {bigint} parameters.amount - The amount to be withdrawn, expressed in satoshis.
+ *
+ * @returns {Hex} - The encoded transaction data.
+ */
+export const encodeInitiateWithdrawal = ({
+  vaultIndex,
+  btcAddress,
+  amount,
+}: {
+  vaultIndex: number;
+  btcAddress: string;
+  amount: bigint;
+}) =>
+  encodeFunctionData({
+    abi: bitcoinTunnelManagerAbi,
+    args: [vaultIndex, btcAddress, amount],
+    functionName: "initiateWithdrawal",
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,16 @@ export { hemi } from "./chains/hemi.js";
 export { hemiSepolia } from "./chains/hemi-sepolia.js";
 
 export * from "./actions/public/bitcoin-kit.js";
+export {
+  encodeChallengeWithdrawal,
+  encodeConfirmDeposit,
+  encodeInitiateWithdrawal,
+} from "./actions/public/bitcoin-tunnel-encoders.js";
 export * from "./actions/public/bitcoin-tunnel-manager.js";
 export * from "./actions/public/simple-bitcoin-vault.js";
 export * from "./actions/public/simple-bitcoin-vault-state.js";
 export * from "./actions/public/get-btc-finality-by-block-hash.js";
+export { bitcoinTunnelManagerAddresses } from "./contracts/bitcoin-tunnel-manager.js";
 
 export { hemiPublicBitcoinKitActions } from "./decorators/public-bitcoin-kit-actions.js";
 export { hemiPublicBitcoinTunnelManagerActions } from "./decorators/public-bitcoin-tunnel-manager-actions.js";


### PR DESCRIPTION
This PR introduces a set of pure encoding functions for Bitcoin Tunnel operations, allowing clients to encode calldata for direct contract interactions.

### Added

- `encodeChallengeWithdrawal`
- `encodeConfirmDeposit`
- `encodeInitiateWithdrawal`

Related to https://github.com/hemilabs/ui-monorepo/issues/866