### PR TITLE
Fix ESM import by ref contract file directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Viem extension for the Hemi network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/public/bitcoin-tunnel-encoders.ts
+++ b/src/actions/public/bitcoin-tunnel-encoders.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, Hash, isHash } from "viem";
-import { bitcoinTunnelManagerAbi } from "../../contracts";
+import { bitcoinTunnelManagerAbi } from "../../contracts/bitcoin-tunnel-manager.js";
 
 /**
  * Encodes the transaction data for challenging a BTC withdrawal using the `challengeWithdrawal` function.


### PR DESCRIPTION
This PR fixes an issue with ES Module resolution in environments like Vitest by updating the import path for the Bitcoin Tunnel manager ABI. Initially, the issue was not detected because local development was using `npm link`, which bypasses strict ESM resolution rules by pointing directly to the source files in the workspace.

Closes #49 