### PR TITLE
Fix eslint warnings

### DIFF
--- a/src/actions/public/bitcoin-tunnel-encoders.ts
+++ b/src/actions/public/bitcoin-tunnel-encoders.ts
@@ -1,4 +1,5 @@
 import { encodeFunctionData, Hash, isHash } from "viem";
+
 import { bitcoinTunnelManagerAbi } from "../../contracts/bitcoin-tunnel-manager.js";
 
 /**
@@ -11,11 +12,11 @@ import { bitcoinTunnelManagerAbi } from "../../contracts/bitcoin-tunnel-manager.
  * @returns {Hex} - The encoded transaction data.
  */
 export const encodeChallengeWithdrawal = ({
-  uuid,
   extraInfo,
+  uuid,
 }: {
-  uuid: bigint;
   extraInfo?: Hash;
+  uuid: bigint;
 }) =>
   encodeFunctionData({
     abi: bitcoinTunnelManagerAbi,
@@ -35,15 +36,15 @@ export const encodeChallengeWithdrawal = ({
  * @returns {Hex} - The encoded transaction data.
  */
 export const encodeConfirmDeposit = ({
-  vaultIndex,
-  txId,
-  outputIndex,
   extraInfo,
+  outputIndex,
+  txId,
+  vaultIndex,
 }: {
-  vaultIndex: number;
-  txId: string;
-  outputIndex: bigint;
   extraInfo: Hash;
+  outputIndex: bigint;
+  txId: string;
+  vaultIndex: number;
 }) =>
   encodeFunctionData({
     abi: bitcoinTunnelManagerAbi,
@@ -67,13 +68,13 @@ export const encodeConfirmDeposit = ({
  * @returns {Hex} - The encoded transaction data.
  */
 export const encodeInitiateWithdrawal = ({
-  vaultIndex,
-  btcAddress,
   amount,
+  btcAddress,
+  vaultIndex,
 }: {
-  vaultIndex: number;
-  btcAddress: string;
   amount: bigint;
+  btcAddress: string;
+  vaultIndex: number;
 }) =>
   encodeFunctionData({
     abi: bitcoinTunnelManagerAbi,

--- a/src/contracts/bitcoin-tunnel-manager.ts
+++ b/src/contracts/bitcoin-tunnel-manager.ts
@@ -1,6 +1,7 @@
 import { type Address, type Chain } from "viem";
-import { hemi } from "../chains/hemi.js";
+
 import { hemiSepolia } from "../chains/hemi-sepolia.js";
+import { hemi } from "../chains/hemi.js";
 
 export const bitcoinTunnelManagerAddresses: Record<Chain["id"], Address> = {
   [hemi.id]: "0xEAcA824F46c000fB89403846Bb57e6b913321081",

--- a/src/decorators/public-bitcoin-kit-actions.ts
+++ b/src/decorators/public-bitcoin-kit-actions.ts
@@ -1,5 +1,6 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as bitcoinKitActions from "../actions/public/bitcoin-kit.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiPublicBitcoinKitActions = () =>
   actionsToDecorator(bitcoinKitActions);

--- a/src/decorators/public-bitcoin-tunnel-manager-actions.ts
+++ b/src/decorators/public-bitcoin-tunnel-manager-actions.ts
@@ -1,5 +1,6 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as bitcoinTunnelManagerActions from "../actions/public/bitcoin-tunnel-manager.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiPublicBitcoinTunnelManagerActions = () =>
   actionsToDecorator(bitcoinTunnelManagerActions);

--- a/src/decorators/public-op-node-actions.ts
+++ b/src/decorators/public-op-node-actions.ts
@@ -1,4 +1,5 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as opNodeActions from "../actions/public/get-btc-finality-by-block-hash.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiPublicOpNodeActions = () => actionsToDecorator(opNodeActions);

--- a/src/decorators/public-simple-bitcoin-vault-actions.ts
+++ b/src/decorators/public-simple-bitcoin-vault-actions.ts
@@ -1,5 +1,6 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as simpleBitcoinVaultActions from "../actions/public/simple-bitcoin-vault.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiPublicSimpleBitcoinVaultActions = () =>
   actionsToDecorator(simpleBitcoinVaultActions);

--- a/src/decorators/public-simple-bitcoin-vault-state-actions.ts
+++ b/src/decorators/public-simple-bitcoin-vault-state-actions.ts
@@ -1,5 +1,6 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as simpleBitcoinVaultStateActions from "../actions/public/simple-bitcoin-vault-state.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiPublicSimpleBitcoinVaultStateActions = () =>
   actionsToDecorator(simpleBitcoinVaultStateActions);

--- a/src/decorators/wallet-bitcoin-tunnel-manager-actions.ts
+++ b/src/decorators/wallet-bitcoin-tunnel-manager-actions.ts
@@ -1,5 +1,6 @@
-import { actionsToDecorator } from "./actions-to-decorator.js";
 import * as bitcoinTunnelManagerActions from "../actions/wallet/bitcoin-tunnel-manager.js";
+
+import { actionsToDecorator } from "./actions-to-decorator.js";
 
 export const hemiWalletBitcoinTunnelManagerActions = () =>
   actionsToDecorator(bitcoinTunnelManagerActions);


### PR DESCRIPTION
There are some ESLint warnings, probably due to the eslint-config-bloq version updated after installing (using `^`). This PR fixes them.