### PR TITLE
Add Bitcoun tunnel fee methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Viem extension for the Hemi network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/public/simple-bitcoin-vault-state.ts
+++ b/src/actions/public/simple-bitcoin-vault-state.ts
@@ -34,6 +34,42 @@ export async function acknowledgedDeposits(
   });
 }
 
+export async function calculateDepositFee(
+  client: Client,
+  parameters: { depositAmount: bigint; vaultStateAddress: Address },
+) {
+  assertObject(parameters, "parameters");
+  const { depositAmount, vaultStateAddress } = parameters;
+
+  assertAddress(vaultStateAddress, "vaultStateAddress");
+  assertBigInt(depositAmount, "depositAmount");
+
+  return readContract(client, {
+    abi: simpleBitcoinVaultStateAbi,
+    address: vaultStateAddress,
+    args: [depositAmount],
+    functionName: "calculateDepositFee",
+  });
+}
+
+export async function calculateWithdrawalFee(
+  client: Client,
+  parameters: { vaultStateAddress: Address; withdrawalAmount: bigint },
+) {
+  assertObject(parameters, "parameters");
+  const { vaultStateAddress, withdrawalAmount } = parameters;
+
+  assertAddress(vaultStateAddress, "vaultStateAddress");
+  assertBigInt(withdrawalAmount, "withdrawalAmount");
+
+  return readContract(client, {
+    abi: simpleBitcoinVaultStateAbi,
+    address: vaultStateAddress,
+    args: [withdrawalAmount],
+    functionName: "calculateWithdrawalFee",
+  });
+}
+
 export async function isBitcoinWithdrawalFulfilled(
   client: Client,
   parameters: { uuid: bigint; vaultStateAddress: Address },


### PR DESCRIPTION
This PR adds 2 methods to calculate tunnel fees

- 04cfa0d8eaa96149f0360e66f6d01d9bcbcb200a Adds `calculateDepositFee` and `calculateWithdrawalFee `
- 3fd92a29711d0ce28228f9e094cbb6a7c298c357 Bumps the package version