### PR TITLE
Fix extra info field hex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hemi-viem",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hemi-viem",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hemi-viem",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Viem extension for the Hemi network",
   "bugs": {
     "url": "https://github.com/hemilabs/hemi-viem/issues"

--- a/src/actions/wallet/bitcoin-tunnel-manager.ts
+++ b/src/actions/wallet/bitcoin-tunnel-manager.ts
@@ -1,4 +1,4 @@
-import { type Address, type Client, type Hash, isHash } from "viem";
+import { type Address, type Client, Hash, type Hex, isHash } from "viem";
 import { writeContract } from "viem/actions";
 
 import {
@@ -8,7 +8,7 @@ import {
 import {
   assertAddress,
   assertBigInt,
-  assertHash,
+  assertHex,
   assertNonEmptyString,
   assertObject,
   assertPositiveInteger,
@@ -17,7 +17,7 @@ import {
 export async function confirmDeposit(
   client: Client,
   parameters: {
-    extraInfo: Hash;
+    extraInfo: Hex;
     from: Address;
     outputIndex: bigint;
     txId: string;
@@ -26,7 +26,7 @@ export async function confirmDeposit(
 ) {
   assertObject(parameters, "parameters");
   const { extraInfo, from, outputIndex, txId, vaultIndex } = parameters;
-  assertHash(extraInfo, "extraInfo");
+  assertHex(extraInfo, "extraInfo");
   assertAddress(from, "from");
   assertBigInt(outputIndex, "outputIndex");
   assertNonEmptyString(txId, "txId");
@@ -70,7 +70,7 @@ export async function initiateWithdrawal(
 export async function challengeWithdrawal(
   client: Client,
   parameters: {
-    extraInfo?: Hash;
+    extraInfo?: Hex;
     from: Address;
     uuid: bigint;
   },
@@ -79,7 +79,7 @@ export async function challengeWithdrawal(
   const { extraInfo = "0x", from, uuid } = parameters;
   assertAddress(from, "from");
   assertBigInt(uuid, "uuid");
-  assertHash(extraInfo, "extraInfo");
+  assertHex(extraInfo, "extraInfo");
 
   return writeContract(client, {
     abi: bitcoinTunnelManagerAbi,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Address, Hash, isAddress, isHash } from "viem";
+import { Address, Hash, Hex, isAddress, isHash, isHex } from "viem";
 
 export function assertNonEmptyString(
   value: unknown,
@@ -41,6 +41,14 @@ export function assertObject(
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(
       `Invalid or missing parameter object: ${name}. Received: ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+export function assertHex(value: unknown, name: string): asserts value is Hex {
+  if (typeof value !== "string" || !isHex(value)) {
+    throw new Error(
+      `Invalid or missing hex parameter: ${name}. Received: ${JSON.stringify(value)}`,
     );
   }
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -7,6 +7,7 @@ import {
   assertAddress,
   assertObject,
   assertHash,
+  assertHex,
   assertBigInt,
 } from "../src/utils";
 
@@ -73,6 +74,21 @@ describe("assertHash", function () {
     expect(() => assertHash("0x123", "test")).toThrow();
     expect(() => assertHash(123, "test")).toThrow();
     expect(() => assertHash(undefined, "test")).toThrow();
+  });
+});
+
+describe("assertHex", function () {
+  it("should not throw for a valid hex", function () {
+    expect(() => assertHex(zeroHash, "test")).not.toThrow();
+    expect(() => assertHex("0x", "test")).not.toThrow();
+    expect(() => assertHex("0x123", "test")).not.toThrow();
+    expect(() => assertHex("0xabcdef", "test")).not.toThrow();
+  });
+  it("should throw for an invalid hex", function () {
+    expect(() => assertHex("123", "test")).toThrow();
+    expect(() => assertHex("0xgg", "test")).toThrow();
+    expect(() => assertHex(123, "test")).toThrow();
+    expect(() => assertHex(undefined, "test")).toThrow();
   });
 });
 


### PR DESCRIPTION
There was a bug that prevented deposits from confirming (and most likely, challenging withdrawals) when the caller did not set the `extraInfo` appropriately. Below is the explanation (+ fix)


The `confirmDeposit` and `challengeWithdrawal` methods accept a field named `extraInfo`. If we don't want to set it, we must send `0x`. The types generated from the ABI dictate it's a mandatory type. In solidity, the appropriate type is `bytes`, which basically matches any `0x${string}` on Typescript.

For that reason, I've used `Hash`, which is defined in `viem` as `0x${string}`. However, when asserting that a value is hash in `utils.ts`, `isHash` performs a few extra checks on the string, because for a string to be a hash, not only must the string match `0x${string}`, but it also has to have a certain length. And of course, the string `0x` does not have that length, causing the method to fail

What I should've used was the type `Hex`, which basically accepts any string, as long as it starts with `0x` and uses only HEX characters. From the Types POV, both `Hex` and `Hash` are equal to `0x${string}`, but in runtime, `isHash` is more restrictive. We should only use it when we expect the string to be an actual hash, like a block or a transaction hash.

In this case, we just needed a hexadecimal value, so `Hex` is ok. The call would fail when sending `0x` from the portal, which is the min value the contract expects if not sending something else.

This must've been broken since the `assertHash` was added, however, as confirming deposits is mostly an automatic process (and the methods fixed are for manual confirmation), this wasn't noticed up to now..