### PR TITLE
ci: pin actions to full-length commit hashes

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -13,6 +13,6 @@ concurrency:
 
 jobs:
   run-checks-and-tests:
-    uses: hemilabs/actions/.github/workflows/js-checks.yml@v1
+    uses: hemilabs/actions/.github/workflows/js-checks.yml@06d5e0813de21d92283163864cce2e95ec5b67c6 # v1.0.0
     with:
       node-versions: '["20", "22", "24"]'


### PR DESCRIPTION
This pull request pins all GitHub Actions to their full-length commit SHAs. Used GitHub Actions have not been updated, and have been pinned to commit hashes for the latest release matching the existing tag.

The organisation-level setting "Require actions to be pinned to a full-length commit SHA" will be enabled on **January 15th, 2026**. Once this setting is active, any workflows referencing actions by tag (e.g., `@v4`) or branch (e.g., `@master`) will fail to execute.

Additionally, the setting "Allow hemilabs, and select non-hemilabs, actions and reusable workflows" will be enabled on the same date. All third-party actions currently in use by this repository have been recorded and will be permitted. **After January 15th, 2026, any new third-party actions must be approved by SecOps before use.**

Pinning actions to immutable commit hashes reduces potential for supply chain attacks by:
- Tag mutation attacks (where a malicious actor overwrites a tag with compromised code)
- Unexpected changes from upstream action updates

For more information, please see:

- [GitHub Docs: Secure use reference - Pin actions to a full-length commit SHA](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions)
- [GitHub Well-Architected: Securing GitHub Actions Workflows](https://wellarchitected.github.com/library/application-security/recommendations/actions-security/)
- [GitHub Blog: Actions policy now supports blocking and SHA pinning](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)

All original version tags are preserved as inline comments for maintainability.

---

This pull request does not update any actions. All actions have been pinned to the most recent commit for the pre-existing tag -- please update actions in a separate pull request if necessary. Pinned actions:

| Action                                             | Update | Change                   |
|----------------------------------------------------|--------|--------------------------|
| `hemilabs/actions/.github/workflows/js-checks.yml` | pin    | `v1 -> v1.0.0 (06d5e08)` |

Detected third-party actions:

```
None detected
```