### PR TITLE
Export missing bitcoin tunnel manager actions

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -14,9 +14,12 @@ export {
 } from "./public/bitcoin-tunnel-encoders.js";
 
 export {
-  getVaultByIndex,
-  getVaultIndexByBTCAddress,
+  getBitcoinChainLastHeader,
   getBitcoinKitAddress,
+  getTunnelManagerStatus,
+  getVaultByIndex,
+  getVaultCounter,
+  getVaultIndexByBTCAddress,
 } from "./public/bitcoin-tunnel-manager.js";
 
 export { getBtcFinalityByBlockHash } from "./public/get-btc-finality-by-block-hash.js";


### PR DESCRIPTION
A few public actions from `bitcoin-tunnel-manager` were implemented but never re-exported from `hemi-viem/actions`, so they couldn't be imported by consumers.

This adds the missing exports: `getBitcoinChainLastHeader`, `getTunnelManagerStatus`, and `getVaultCounter`.

No bump version because I'm also adding other changes in future PRs (bumping deps basically)