### PR TITLE
Bump knip to 6.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "^8.57.1",
     "eslint-config-bloq": "^4.6.0",
     "husky": "^9.1.7",
-    "knip": "^5.41.1",
+    "knip": "^6.18.0",
     "lint-staged": "^15.3.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       knip:
-        specifier: ^5.41.1
-        version: 5.88.1(@types/node@26.0.0)(typescript@5.9.3)
+        specifier: ^6.18.0
+        version: 6.18.0
       lint-staged:
         specifier: ^15.3.0
         version: 15.5.2
@@ -339,6 +339,13 @@ packages:
         tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz,
       }
 
+  "@emnapi/core@1.11.1":
+    resolution:
+      {
+        integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
+        tarball: https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz,
+      }
+
   "@emnapi/runtime@1.10.0":
     resolution:
       {
@@ -351,6 +358,13 @@ packages:
       {
         integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
         tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz,
+      }
+
+  "@emnapi/runtime@1.11.1":
+    resolution:
+      {
+        integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+        tarball: https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz,
       }
 
   "@emnapi/wasi-threads@1.2.1":
@@ -802,6 +816,220 @@ packages:
         tarball: https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz,
       }
     engines: { node: ">=12.4.0" }
+
+  "@oxc-parser/binding-android-arm-eabi@0.137.0":
+    resolution:
+      {
+        integrity: sha512-KDs+0VPdEmasOkpuJHW9V5WCF+cvYdMQv2Jd+aJXt+cxIx12NToRQRbXaRwUEDsZw+/jMk81Ve8ZFbjUkJTOwA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@oxc-parser/binding-android-arm64@0.137.0":
+    resolution:
+      {
+        integrity: sha512-WhALNzfy3x/RfC6bsqX+csavuUY0yHHE7XfgPE5M542uhoBZUUoGTPG+nkMbGoG4+gcfss5s7urMyn5QBHu0sw==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [android]
+
+  "@oxc-parser/binding-darwin-arm64@0.137.0":
+    resolution:
+      {
+        integrity: sha512-bFPr5hgmNMOMoyPTGtdsK4Ug21RovIPojRMgDDhSp1LtCnc/DkLwGONKjgRjszg677RlGnkYSviQ8hHaUPOVYA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@oxc-parser/binding-darwin-x64@0.137.0":
+    resolution:
+      {
+        integrity: sha512-CL5dMm1asqXIDZHg14FLxj3Mc36w8PI7xCWh1uA4is6z8g2XrIILoTcQYOxDbwzuk34RDPX5IAGUxZr6LA9KAg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@oxc-parser/binding-freebsd-x64@0.137.0":
+    resolution:
+      {
+        integrity: sha512-79h8rYGnSlKPGWo7mHr2ixO6ea7aW8B0CT965SZ8SLbNnCOH5aOYBTeVXUY6eMvEaiLyWr8Skuiugr5pDYgLGw==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.137.0":
+    resolution:
+      {
+        integrity: sha512-ASgmlSimhGyr0lksgVIo6hibz1obnDq4qJbiMX/AzltfgPnanRrzG1Q+23g8ljOHOjv6dsznkUuCYL3gg0sY1Q==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.137.0":
+    resolution:
+      {
+        integrity: sha512-AU2J9aa22Sx32wRGnDjybOU9TQXXQUud5sdUi+ZB0XxwM8aToWLweV+yA0wlQm0yIUVqljquqoHCYEq9II8gJQ==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [linux]
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.137.0":
+    resolution:
+      {
+        integrity: sha512-GdEtiG89yMr7XkUGxifgodXEEm2f+xW2f9CpDjlgAnBOwhTmrpQMvhOGobLVKUyzf/qHBXW16smk5zbF3nZU6w==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-arm64-musl@0.137.0":
+    resolution:
+      {
+        integrity: sha512-EGJ+Bs8iXx8KBH8DQ5BLoEm5lnHaYjlh4/8j8vFhrr/6z4tqONy5BZDzLpKmmNWlN6Hlc5r8YOuBVHqZ9vRFEQ==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.137.0":
+    resolution:
+      {
+        integrity: sha512-vzFUQENy/fnbSe5DZWovq6tIBc1uhuMztanSW6rz1e9WdQE4gHwYuD7ZII6JnrJifd1R3RSoqiZbgRFlVL2tYQ==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.137.0":
+    resolution:
+      {
+        integrity: sha512-SfVI14HBQs9gtLcUD5hTt5hsNbdrqSUNg9S8muN+LhVQ5nf1WwH3hAoK6B9NKgdYgWAQSXFXGiiBedQ4r/BKuw==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.137.0":
+    resolution:
+      {
+        integrity: sha512-e7Ppy4FCIFNQxT/ikSeIWFoQ0l+N9vgtRBtLcyZXeolTzApyVoPqEXsYPrcdM/9i0Bwk8knvYd37vaEMxHyi6g==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.137.0":
+    resolution:
+      {
+        integrity: sha512-Bho5qFwdhqsIFR7gipYEUlqvi3SRrY8sugxXig380MIaakBB1PyU9+7dBiBVScfImTNWhijUxdBwqrprGdq5WA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-gnu@0.137.0":
+    resolution:
+      {
+        integrity: sha512-36mGWtg7PyFzjJwGDkH6/F4o2nIDEoKXLPr/X/lwqklkomQwJJt1I5GJVmGhovUEmgPK5WAeAZMqlFCehwiy9Q==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@oxc-parser/binding-linux-x64-musl@0.137.0":
+    resolution:
+      {
+        integrity: sha512-/Jqx6+N7A44n2BdvUr7pXhVr2vFjs6WGH3unZRczwrfiH0H1zY0QwKQMG/dtRiTlKGDKGukznPT8lx84/oEsZg==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@oxc-parser/binding-openharmony-arm64@0.137.0":
+    resolution:
+      {
+        integrity: sha512-9Uj0qHNNl+OgT1UTGwF7ixIXU6T1u2SbMidmgPy/h1h/fl2gRS6YpAxxY1gwHofcWjoTwkoMFd8xs5Vuj6GOFA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@oxc-parser/binding-wasm32-wasi@0.137.0":
+    resolution:
+      {
+        integrity: sha512-gW2vfkytNGgMVADiuzdvOfw0mWG9za20F/1fCJsif5aBMAvWJTSbpIXbIe0XkOe0VENk+PadpQ7cZgUy2sUJcA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [wasm32]
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.137.0":
+    resolution:
+      {
+        integrity: sha512-x+pFANF0yL5uK/6T7lu6SlR5qid6sp//eZXKLq5iNsIE+EQg6EaS8/wsW7E91nXXjpnPhSoMOHXShSVhGRdn8w==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.137.0":
+    resolution:
+      {
+        integrity: sha512-sQUqym80PFi6McRsIqfJrSu2JrSClEZIXXD+/FjAFoULEKzOPsldIdFBG96xdX8aVMzCNQ9792FPx3MfkEIrFA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@oxc-parser/binding-win32-x64-msvc@0.137.0":
+    resolution:
+      {
+        integrity: sha512-2AsevxlvNN4WKxpEn3RtqD5zbqMaXF+T7JXblsP4gVuY+vC9dXS4ED/PwfRCliFqoeisYS3Iro4DHzxr0TEvVA==,
+        tarball: https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@oxc-project/types@0.137.0":
+    resolution:
+      {
+        integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==,
+        tarball: https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz,
+      }
 
   "@oxc-resolver/binding-android-arm-eabi@11.21.3":
     resolution:
@@ -4019,17 +4247,14 @@ packages:
         tarball: https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz,
       }
 
-  knip@5.88.1:
+  knip@6.18.0:
     resolution:
       {
-        integrity: sha512-tpy5o7zu1MjawVkLPuahymVJekYY3kYjvzcoInhIchgePxTlo+api90tBv2KfhAIe5uXh+mez1tAfmbv8/TiZg==,
-        tarball: https://registry.npmjs.org/knip/-/knip-5.88.1.tgz,
+        integrity: sha512-RlT6fK3epETsEUCVdlz96CiJN3DQJwuxOuQhEeAVWjNRuAUJHWwe+XolTL8vIiwLPZ38tTdPWJUgZyTdskOEog==,
+        tarball: https://registry.npmjs.org/knip/-/knip-6.18.0.tgz,
       }
-    engines: { node: ">=18.18.0" }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
-    peerDependencies:
-      "@types/node": ">=18"
-      typescript: ">=5.0.4 <7"
 
   language-subtag-registry@0.3.23:
     resolution:
@@ -4502,6 +4727,14 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  oxc-parser@0.137.0:
+    resolution:
+      {
+        integrity: sha512-yFImD+WLElJpLKy8llG1qe4DCmMsL18peRp8XP1JKfig/gISbJkglnpDtX2aTmAn10kZF7164HbN2H8QPsXxGg==,
+        tarball: https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.137.0.tgz,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
 
   oxc-resolver@11.21.3:
     resolution:
@@ -5456,11 +5689,11 @@ packages:
         tarball: https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz,
       }
 
-  unbash@2.2.0:
+  unbash@4.0.1:
     resolution:
       {
-        integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==,
-        tarball: https://registry.npmjs.org/unbash/-/unbash-2.2.0.tgz,
+        integrity: sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==,
+        tarball: https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz,
       }
     engines: { node: ">=14" }
 
@@ -6016,12 +6249,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@emnapi/core@1.11.1":
+    dependencies:
+      "@emnapi/wasi-threads": 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   "@emnapi/runtime@1.10.0":
     dependencies:
       tslib: 2.8.1
     optional: true
 
   "@emnapi/runtime@1.11.0":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@emnapi/runtime@1.11.1":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6188,6 +6432,13 @@ snapshots:
       "@tybys/wasm-util": 0.10.2
     optional: true
 
+  "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
+    dependencies:
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@tybys/wasm-util": 0.10.2
+    optional: true
+
   "@next/eslint-plugin-next@13.5.11":
     dependencies:
       glob: 7.1.7
@@ -6213,6 +6464,72 @@ snapshots:
       fastq: 1.20.1
 
   "@nolyfill/is-core-module@1.0.39": {}
+
+  "@oxc-parser/binding-android-arm-eabi@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-android-arm64@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-arm64@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-darwin-x64@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-freebsd-x64@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-gnueabihf@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm-musleabihf@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-gnu@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-arm64-musl@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-ppc64-gnu@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-gnu@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-riscv64-musl@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-s390x-gnu@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-gnu@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-linux-x64-musl@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-openharmony-arm64@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-wasm32-wasi@0.137.0":
+    dependencies:
+      "@emnapi/core": 1.11.1
+      "@emnapi/runtime": 1.11.1
+      "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  "@oxc-parser/binding-win32-arm64-msvc@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-ia32-msvc@0.137.0":
+    optional: true
+
+  "@oxc-parser/binding-win32-x64-msvc@0.137.0":
+    optional: true
+
+  "@oxc-project/types@0.137.0": {}
 
   "@oxc-resolver/binding-android-arm-eabi@11.21.3":
     optional: true
@@ -8020,21 +8337,19 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.88.1(@types/node@26.0.0)(typescript@5.9.3):
+  knip@6.18.0:
     dependencies:
-      "@nodelib/fs.walk": 1.2.8
-      "@types/node": 26.0.0
-      fast-glob: 3.3.3
+      fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
+      get-tsconfig: 4.14.0
       jiti: 2.7.0
-      minimist: 1.2.8
+      oxc-parser: 0.137.0
       oxc-resolver: 11.21.3
-      picocolors: 1.1.1
       picomatch: 4.0.4
       smol-toml: 1.7.0
       strip-json-comments: 5.0.3
-      typescript: 5.9.3
-      unbash: 2.2.0
+      tinyglobby: 0.2.17
+      unbash: 4.0.1
       yaml: 2.9.0
       zod: 4.4.3
 
@@ -8284,6 +8599,31 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
+
+  oxc-parser@0.137.0:
+    dependencies:
+      "@oxc-project/types": 0.137.0
+    optionalDependencies:
+      "@oxc-parser/binding-android-arm-eabi": 0.137.0
+      "@oxc-parser/binding-android-arm64": 0.137.0
+      "@oxc-parser/binding-darwin-arm64": 0.137.0
+      "@oxc-parser/binding-darwin-x64": 0.137.0
+      "@oxc-parser/binding-freebsd-x64": 0.137.0
+      "@oxc-parser/binding-linux-arm-gnueabihf": 0.137.0
+      "@oxc-parser/binding-linux-arm-musleabihf": 0.137.0
+      "@oxc-parser/binding-linux-arm64-gnu": 0.137.0
+      "@oxc-parser/binding-linux-arm64-musl": 0.137.0
+      "@oxc-parser/binding-linux-ppc64-gnu": 0.137.0
+      "@oxc-parser/binding-linux-riscv64-gnu": 0.137.0
+      "@oxc-parser/binding-linux-riscv64-musl": 0.137.0
+      "@oxc-parser/binding-linux-s390x-gnu": 0.137.0
+      "@oxc-parser/binding-linux-x64-gnu": 0.137.0
+      "@oxc-parser/binding-linux-x64-musl": 0.137.0
+      "@oxc-parser/binding-openharmony-arm64": 0.137.0
+      "@oxc-parser/binding-wasm32-wasi": 0.137.0
+      "@oxc-parser/binding-win32-arm64-msvc": 0.137.0
+      "@oxc-parser/binding-win32-ia32-msvc": 0.137.0
+      "@oxc-parser/binding-win32-x64-msvc": 0.137.0
 
   oxc-resolver@11.21.3:
     optionalDependencies:
@@ -8806,7 +9146,7 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  unbash@2.2.0: {}
+  unbash@4.0.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
## Description

Bumps `knip` from `^5.41.1` to `^6.18.0`.

knip 6 is a major release. The notable change for this repo is the raised runtime requirement (`node: ^20.19.0 || >=22.12.0`); CI already runs on Node 22 and 24, so it remains compatible. Internally knip 6 swaps its parser/resolver stack (now `oxc-parser`, `tinyglobby`, `fdir`) and drops the `@types/node`/`typescript` peer dependencies, which is reflected in the lockfile.

`pnpm deps:check` (`knip --production`, the command used here and in CI) continues to report no issues.

## Notes

No version bump is included here on purpose, consistent with the other in-flight toolchain PRs.